### PR TITLE
Feature/4 crustaceans

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,18 @@ services:
       context: .
     ports:
       - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql-db:3306/animals?createDatabaseIfNotExist=true
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: password
+
+  db:
+    image: mysql:latest
+    container_name: mysql-db
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+    ports:
+      - "3306:3306"
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - db
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql-db:3306/animals?createDatabaseIfNotExist=true
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql-db:3306/animals?createDatabaseIfNotExist=true&autoReconnect=true
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: password
 
@@ -17,7 +17,9 @@ services:
     image: mysql:latest
     container_name: mysql-db
     environment:
+      - MYSQL_DATABASE=animals
       - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_PASSWORD=password
     ports:
       - "3306:3306"
     restart: always

--- a/pom.xml
+++ b/pom.xml
@@ -1,113 +1,134 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.5.RELEASE</version>
-        <relativePath/> <!-- lookup parent from repository -->
-    </parent>
-    <groupId>cx.catapult</groupId>
-    <artifactId>animals-api</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <name>animals-api</name>
-    <description>Animals API</description>
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.2.5.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>cx.catapult</groupId>
+	<artifactId>animals-api</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>animals-api</name>
+	<description>Animals API</description>
 
     <properties>
         <java.version>1.8</java.version>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>5.4.30.Final</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>8.0.23</version>
+			<scope>runtime</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.vintage</groupId>
+					<artifactId>junit-vintage-engine</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>nl.jqno.equalsverifier</groupId>
 			<artifactId>equalsverifier</artifactId>
 			<version>3.6</version>
 			<scope>test</scope>
 		</dependency>
-    </dependencies>
+	</dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.3</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>jacoco-check</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <rule>
-                                    <element>BUNDLE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.95</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                                <rule>
-                                    <element>PACKAGE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.3</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>jacoco-check</id>
+						<phase>test</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.95</minimum>
+										</limit>
+									</limits>
+								</rule>
+								<rule>
+									<element>PACKAGE</element>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.70</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+		<dependency>
+			<groupId>nl.jqno.equalsverifier</groupId>
+			<artifactId>equalsverifier</artifactId>
+			<version>3.6</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/cx/catapult/animals/AnimalsApiApplication.java
+++ b/src/main/java/cx/catapult/animals/AnimalsApiApplication.java
@@ -1,14 +1,19 @@
 package cx.catapult.animals;
 
+import java.util.Arrays;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-
-import java.util.Arrays;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @SpringBootApplication
+@EnableAutoConfiguration
+@EnableJpaRepositories(basePackages = "cx.catapult.animals.repository")
+@EnableTransactionManagement
 public class AnimalsApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/cx/catapult/animals/domain/BaseAnimal.java
+++ b/src/main/java/cx/catapult/animals/domain/BaseAnimal.java
@@ -2,13 +2,28 @@ package cx.catapult.animals.domain;
 
 import java.io.Serializable;
 import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
 
+@Entity
+@Table(name = "Animal")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "discriminator")
 public class BaseAnimal implements Animal, Serializable {
-
+	@Id
     private String id;
-    private String name;
-    private String description;
-    private Group group;
+	private String name;
+	private String description;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "group_name")
+	private Group group;
 
     public BaseAnimal(String name, String description, Group group) {
         this(null, name, description, group);

--- a/src/main/java/cx/catapult/animals/domain/BaseAnimal.java
+++ b/src/main/java/cx/catapult/animals/domain/BaseAnimal.java
@@ -11,6 +11,7 @@ import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.Table;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 @Entity
 @Table(name = "Animal")
@@ -29,6 +30,7 @@ public class BaseAnimal implements Animal, Serializable {
         this(null, name, description, group);
     }
 
+    @JsonCreator
     public BaseAnimal(String id, String name, String description, Group group) {
         this.id = id;
         this.name = name;

--- a/src/main/java/cx/catapult/animals/domain/BaseAnimal.java
+++ b/src/main/java/cx/catapult/animals/domain/BaseAnimal.java
@@ -1,6 +1,7 @@
 package cx.catapult.animals.domain;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class BaseAnimal implements Animal, Serializable {
 
@@ -54,4 +55,24 @@ public class BaseAnimal implements Animal, Serializable {
     public Group getGroup() {
         return this.group;
     }
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		BaseAnimal that = (BaseAnimal) o;
+		return Objects.equals(id, that.id) &&
+				Objects.equals(name, that.name) &&
+				Objects.equals(description, that.description) &&
+				group == that.group;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, name, description, group);
+	}
 }

--- a/src/main/java/cx/catapult/animals/domain/Cat.java
+++ b/src/main/java/cx/catapult/animals/domain/Cat.java
@@ -1,5 +1,10 @@
 package cx.catapult.animals.domain;
 
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@Entity
+@DiscriminatorValue(value = "MAMMALS")
 public class Cat extends BaseAnimal {
     public Cat() {
         this("", "");

--- a/src/main/java/cx/catapult/animals/domain/Crustacean.java
+++ b/src/main/java/cx/catapult/animals/domain/Crustacean.java
@@ -1,9 +1,14 @@
 package cx.catapult.animals.domain;
 
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
 /**
  * A Crustacean is a type of invertebrate, which includes animals such as crabs, lobsters, crayfish, shrimps
  * and prawns.
  */
+@Entity
+@DiscriminatorValue(value = "INVERTEBRATE")
 public class Crustacean extends BaseAnimal {
     public Crustacean() {
         this("", "");

--- a/src/main/java/cx/catapult/animals/domain/Crustacean.java
+++ b/src/main/java/cx/catapult/animals/domain/Crustacean.java
@@ -1,0 +1,15 @@
+package cx.catapult.animals.domain;
+
+/**
+ * A Crustacean is a type of invertebrate, which includes animals such as crabs, lobsters, crayfish, shrimps
+ * and prawns.
+ */
+public class Crustacean extends BaseAnimal {
+    public Crustacean() {
+        this("", "");
+    }
+
+    public Crustacean(String name, String description) {
+        super(name, description, Group.INVERTEBRATE);
+    }
+}

--- a/src/main/java/cx/catapult/animals/repository/AnimalsRepository.java
+++ b/src/main/java/cx/catapult/animals/repository/AnimalsRepository.java
@@ -1,10 +1,25 @@
 package cx.catapult.animals.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import cx.catapult.animals.domain.BaseAnimal;
 
 @Repository
 public interface AnimalsRepository<T extends BaseAnimal> extends JpaRepository<T, String> {
+
+	@Query(
+			value = "select * from animal u where u.id = ?1",
+			nativeQuery = true
+	)
+	Optional<T> findById(String id);
+
+	@Query(
+			value = "select * from animal u where u.name = ?1",
+			nativeQuery = true
+	)
+	List<T> findByName(String name);
 }

--- a/src/main/java/cx/catapult/animals/repository/AnimalsRepository.java
+++ b/src/main/java/cx/catapult/animals/repository/AnimalsRepository.java
@@ -1,0 +1,10 @@
+package cx.catapult.animals.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import cx.catapult.animals.domain.BaseAnimal;
+
+@Repository
+public interface AnimalsRepository<T extends BaseAnimal> extends JpaRepository<T, String> {
+}

--- a/src/main/java/cx/catapult/animals/repository/CatsRepository.java
+++ b/src/main/java/cx/catapult/animals/repository/CatsRepository.java
@@ -1,0 +1,14 @@
+package cx.catapult.animals.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import cx.catapult.animals.domain.Cat;
+
+@Repository
+public interface CatsRepository extends AnimalsRepository<Cat> {
+
+	@Query("from Cat")
+	List<Cat> getAll();
+}

--- a/src/main/java/cx/catapult/animals/repository/CrustaceansRepository.java
+++ b/src/main/java/cx/catapult/animals/repository/CrustaceansRepository.java
@@ -1,0 +1,14 @@
+package cx.catapult.animals.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import cx.catapult.animals.domain.Crustacean;
+
+@Repository
+public interface CrustaceansRepository extends AnimalsRepository<Crustacean> {
+
+	@Query("from Crustacean")
+	List<Crustacean> getAll();
+}

--- a/src/main/java/cx/catapult/animals/service/AnimalsService.java
+++ b/src/main/java/cx/catapult/animals/service/AnimalsService.java
@@ -1,0 +1,29 @@
+package cx.catapult.animals.service;
+
+import java.util.Collection;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import cx.catapult.animals.domain.BaseAnimal;
+import cx.catapult.animals.repository.AnimalsRepository;
+
+/**
+ * Service for retrieving all types of {@link BaseAnimal} types.
+ */
+@Service
+public class AnimalsService<T extends BaseAnimal> {
+
+	private final AnimalsRepository<T> repository;
+
+	public AnimalsService(@Qualifier("animalsRepository") AnimalsRepository<T> repository) {
+		this.repository = repository;
+	}
+
+	public T get(String id) {
+		return repository.findById(id).orElse(null);
+	}
+
+	public Collection<T> getByName(String name) {
+		return repository.findByName(name);
+	}
+}

--- a/src/main/java/cx/catapult/animals/service/BaseService.java
+++ b/src/main/java/cx/catapult/animals/service/BaseService.java
@@ -28,7 +28,19 @@ public abstract class BaseService<T extends Animal> implements Service<T> {
         return items.get(id);
     }
 
-    @Override
+	@Override
+	public T update(String id, T updatedAnimal) {
+		T existingAnimal = get(id);
+		if (existingAnimal == null) {
+			return null;
+		}
+
+		existingAnimal.setName(updatedAnimal.getName());
+		existingAnimal.setDescription(updatedAnimal.getDescription());
+		return existingAnimal;
+	}
+
+	@Override
 	public boolean delete(String id) {
 		return items.remove(id) != null;
 	}

--- a/src/main/java/cx/catapult/animals/service/BaseService.java
+++ b/src/main/java/cx/catapult/animals/service/BaseService.java
@@ -4,33 +4,34 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.UUID;
 
-import cx.catapult.animals.domain.Animal;
+import cx.catapult.animals.domain.BaseAnimal;
 
-public abstract class BaseService<T extends Animal> implements Service<T> {
+public abstract class BaseService<T extends BaseAnimal> implements Service<T> {
 
-    private HashMap<String, T> items = new HashMap<>();
+	// HashMap is non synchronized and its use in this class is not thread safe
+	private final HashMap<String, T> items = new HashMap<>();
 
-    @Override
-    public Collection<T> all() {
-        return items.values();
-    }
+	@Override
+	public Collection<T> all() {
+		return items.values();
+	}
 
-    @Override
-    public T create(T animal) {
-        String id = UUID.randomUUID().toString();
-        animal.setId(id);
-        items.put(id, animal);
-        return animal;
-    }
+	@Override
+	public T create(T animal) {
+		String id = UUID.randomUUID().toString();
+		animal.setId(id);
+		items.put(id, animal);
+		return animal;
+	}
 
-    @Override
-    public T get(String id) {
-        return items.get(id);
-    }
+	@Override
+	public T get(String id) {
+		return items.get(id);
+	}
 
 	@Override
 	public T update(String id, T updatedAnimal) {
-		T existingAnimal = get(id);
+		T existingAnimal = items.get(id);
 		if (existingAnimal == null) {
 			return null;
 		}

--- a/src/main/java/cx/catapult/animals/service/BaseService.java
+++ b/src/main/java/cx/catapult/animals/service/BaseService.java
@@ -1,8 +1,10 @@
 package cx.catapult.animals.service;
 
-import cx.catapult.animals.domain.Animal;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.UUID;
 
-import java.util.*;
+import cx.catapult.animals.domain.Animal;
 
 public abstract class BaseService<T extends Animal> implements Service<T> {
 
@@ -25,4 +27,9 @@ public abstract class BaseService<T extends Animal> implements Service<T> {
     public T get(String id) {
         return items.get(id);
     }
+
+    @Override
+	public boolean delete(String id) {
+		return items.remove(id) != null;
+	}
 }

--- a/src/main/java/cx/catapult/animals/service/CatsService.java
+++ b/src/main/java/cx/catapult/animals/service/CatsService.java
@@ -1,14 +1,23 @@
 package cx.catapult.animals.service;
 
-import cx.catapult.animals.domain.Cat;
+import java.util.Collection;
+import javax.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
+import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.repository.CatsRepository;
 
 @Service
-public class CatsService extends BaseService<Cat> {
+public class CatsService extends PersistenceService<Cat> {
 
-    @PostConstruct
+	private final CatsRepository repository;
+
+	public CatsService(CatsRepository repository) {
+		super(repository);
+		this.repository = repository;
+	}
+
+	@PostConstruct
     public void initialize() {
         this.create(new Cat("Tom", "Friend of Jerry"));
         this.create(new Cat("Jerry", "Not really a cat"));
@@ -19,4 +28,9 @@ public class CatsService extends BaseService<Cat> {
         this.create(new Cat("Garfield", "Lazy cat"));
     }
 
+	@Override
+	public Collection<Cat> all() {
+		// not sure what should happen here - retrieve from memory or db?
+		return repository.getAll();
+	}
 }

--- a/src/main/java/cx/catapult/animals/service/CrustaceansService.java
+++ b/src/main/java/cx/catapult/animals/service/CrustaceansService.java
@@ -1,9 +1,17 @@
 package cx.catapult.animals.service;
 
+import javax.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
 import cx.catapult.animals.domain.Crustacean;
 
 @Service
 public class CrustaceansService extends BaseService<Crustacean> {
+
+	@PostConstruct
+	public void initialize() {
+		this.create(new Crustacean("Crusty", "Crusty the crab"));
+		this.create(new Crustacean("Libby", "Libby the Lobster"));
+		this.create(new Crustacean("Paula", "Paula the Prawn"));
+	}
 }

--- a/src/main/java/cx/catapult/animals/service/CrustaceansService.java
+++ b/src/main/java/cx/catapult/animals/service/CrustaceansService.java
@@ -1,0 +1,9 @@
+package cx.catapult.animals.service;
+
+import org.springframework.stereotype.Service;
+
+import cx.catapult.animals.domain.Crustacean;
+
+@Service
+public class CrustaceansService extends BaseService<Crustacean> {
+}

--- a/src/main/java/cx/catapult/animals/service/CrustaceansService.java
+++ b/src/main/java/cx/catapult/animals/service/CrustaceansService.java
@@ -1,17 +1,31 @@
 package cx.catapult.animals.service;
 
+import java.util.Collection;
 import javax.annotation.PostConstruct;
 import org.springframework.stereotype.Service;
 
 import cx.catapult.animals.domain.Crustacean;
+import cx.catapult.animals.repository.CrustaceansRepository;
 
 @Service
-public class CrustaceansService extends BaseService<Crustacean> {
+public class CrustaceansService extends PersistenceService<Crustacean> {
+
+	private final CrustaceansRepository repository;
+
+	public CrustaceansService(CrustaceansRepository repository) {
+		super(repository);
+		this.repository = repository;
+	}
 
 	@PostConstruct
 	public void initialize() {
 		this.create(new Crustacean("Crusty", "Crusty the crab"));
 		this.create(new Crustacean("Libby", "Libby the Lobster"));
 		this.create(new Crustacean("Paula", "Paula the Prawn"));
+	}
+
+	@Override
+	public Collection<Crustacean> all() {
+		return repository.getAll();
 	}
 }

--- a/src/main/java/cx/catapult/animals/service/CrustaceansService.java
+++ b/src/main/java/cx/catapult/animals/service/CrustaceansService.java
@@ -19,9 +19,10 @@ public class CrustaceansService extends PersistenceService<Crustacean> {
 
 	@PostConstruct
 	public void initialize() {
-		this.create(new Crustacean("Crusty", "Crusty the crab"));
+		this.create(new Crustacean("Crusty", "Crusty the Crab"));
 		this.create(new Crustacean("Libby", "Libby the Lobster"));
 		this.create(new Crustacean("Paula", "Paula the Prawn"));
+		this.create(new Crustacean("Smelly", "Smelly the Barnacle"));
 	}
 
 	@Override

--- a/src/main/java/cx/catapult/animals/service/PersistenceService.java
+++ b/src/main/java/cx/catapult/animals/service/PersistenceService.java
@@ -1,0 +1,80 @@
+package cx.catapult.animals.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
+
+import cx.catapult.animals.domain.BaseAnimal;
+import cx.catapult.animals.repository.AnimalsRepository;
+
+/**
+ * Extends the in-memory functionality of the {@link BaseService} by providing persistent database storage
+ * and retrieval.
+ *
+ * <p>Acceptance Criteria: Must be [sic] keep existing in memory backend (BaseService) in the code.</p>
+ *
+ * <p>Does this mean items should still be stored in memory? If so, is the (non thread safe) memory storage
+ * meant to act as a cache? This is my interpretation of the requirements, but I would never recommend
+ * implementing a cache this way!
+ *
+ * @param <T> The type of the {@link BaseAnimal} in question.
+ */
+public abstract class PersistenceService<T extends BaseAnimal> extends BaseService<T> {
+
+	private static final Logger logger = LoggerFactory.getLogger(PersistenceService.class);
+
+	private final AnimalsRepository<T> repository;
+
+	public PersistenceService(AnimalsRepository<T> repository) {
+		this.repository = repository;
+	}
+
+	@Override
+	public T create(T animal) {
+		// generate its id and insert into memory, before persisting in the db
+		super.create(animal);
+
+		repository.save(animal);
+		return animal;
+	}
+
+	@Override
+	public T get(String id) {
+		// first get it from memory
+		T cat = super.get(id);
+
+		if (cat == null) {
+			cat = repository.findById(id).orElse(null);
+		}
+		return cat;
+	}
+
+	@Override
+	public T update(String id, T updatedAnimal) {
+		// update the instance in memory and then the db
+		super.update(id, updatedAnimal);
+
+		T existingAnimal = repository.findById(id).orElse(null);
+		if (existingAnimal != null) {
+			existingAnimal.setName(updatedAnimal.getName());
+			existingAnimal.setDescription(updatedAnimal.getDescription());
+			repository.save(existingAnimal);
+		}
+
+		return existingAnimal;
+	}
+
+	@Override
+	public boolean delete(String id) {
+		// remove from memory and then the db
+		super.delete(id);
+
+		try {
+			repository.deleteById(id);
+		} catch (EmptyResultDataAccessException e) {
+			logger.warn("Failed to delete Animal with id [{}]", id);
+			return false;
+		}
+		return true;
+	}
+}

--- a/src/main/java/cx/catapult/animals/service/Service.java
+++ b/src/main/java/cx/catapult/animals/service/Service.java
@@ -1,15 +1,42 @@
 package cx.catapult.animals.service;
 
-import cx.catapult.animals.domain.Animal;
-
 import java.util.Collection;
 
+import cx.catapult.animals.domain.Animal;
+
+/**
+ * Interface defining the common service operations on any type of {@link Animal}.
+ *
+ * @param <T> The type of the {@link Animal} in question.
+ */
 public interface Service<T extends Animal> {
 
-    public Collection<T> all();
+	/**
+	 * Retrieves all of the available instances of a particular type of {@link Animal}.
+	 *
+	 * @return {@link Collection} of the {@link Animal}.
+	 */
+    Collection<T> all();
 
+	/**
+	 * Persists the provided {@link Animal} instance.
+	 *
+	 * @param animal The {@link Animal} to persist.
+	 */
     T create(T animal);
 
-    public T get(String id);
+	/**
+	 * Retrieves the desired {@link Animal} by its ID.
+	 *
+	 * @return The requested {@link Animal} or {@code null} if it doesn't exist.
+	 */
+    T get(String id);
 
+	/**
+	 * Deletes an {@link Animal} by its ID.
+	 *
+	 * @param id The ID of the {@link Animal} to delete.
+	 * @return {@code true} if the {@link Animal} is deleted successfully.
+	 */
+	boolean delete(String id);
 }

--- a/src/main/java/cx/catapult/animals/service/Service.java
+++ b/src/main/java/cx/catapult/animals/service/Service.java
@@ -33,6 +33,13 @@ public interface Service<T extends Animal> {
     T get(String id);
 
 	/**
+	 * Updates the name and/or description of an existing {@link Animal}.
+	 *
+	 * @return The updated {@link Animal} or {@code null} if it doesn't exist.
+	 */
+	T update(String id, T animal);
+
+	/**
 	 * Deletes an {@link Animal} by its ID.
 	 *
 	 * @param id The ID of the {@link Animal} to delete.

--- a/src/main/java/cx/catapult/animals/web/AnimalsController.java
+++ b/src/main/java/cx/catapult/animals/web/AnimalsController.java
@@ -1,0 +1,32 @@
+package cx.catapult.animals.web;
+
+import java.util.Collection;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import cx.catapult.animals.domain.BaseAnimal;
+import cx.catapult.animals.service.AnimalsService;
+
+@RestController
+@RequestMapping(path = "/api/1/animals", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AnimalsController {
+
+	@Autowired
+	private AnimalsService service;
+
+	@GetMapping(value = "/{id}")
+	public @ResponseBody BaseAnimal get(@PathVariable String id) {
+		return service.get(id);
+	}
+
+	@GetMapping
+	public @ResponseBody Collection<BaseAnimal> getByName(@RequestParam String name) {
+		return service.getByName(name);
+	}
+}

--- a/src/main/java/cx/catapult/animals/web/CatsController.java
+++ b/src/main/java/cx/catapult/animals/web/CatsController.java
@@ -1,12 +1,17 @@
 package cx.catapult.animals.web;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
 import java.util.Collection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -38,4 +43,13 @@ public class CatsController {
 	public @ResponseBody Cat create(@RequestBody Cat cat) {
         return service.create(cat);
     }
+
+	@PutMapping(value = "/{id}")
+	public ResponseEntity<Void> update(@PathVariable String id, @RequestBody Cat cat) {
+		if (service.update(id, cat) == null) {
+			return new ResponseEntity<>(NOT_FOUND);
+		}
+
+		return new ResponseEntity<>(NO_CONTENT);
+	}
 }

--- a/src/main/java/cx/catapult/animals/web/CatsController.java
+++ b/src/main/java/cx/catapult/animals/web/CatsController.java
@@ -1,13 +1,20 @@
 package cx.catapult.animals.web;
 
-import cx.catapult.animals.domain.Cat;
-import cx.catapult.animals.service.CatsService;
+import java.util.Collection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Collection;
+import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.service.CatsService;
 
 @RestController
 @RequestMapping(path = "/api/1/cats", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -17,22 +24,18 @@ public class CatsController {
     private CatsService service;
 
     @GetMapping(value = "", produces = "application/json")
-    public @ResponseBody
-    Collection<Cat> all() {
+    public @ResponseBody Collection<Cat> all() {
         return service.all();
     }
 
     @GetMapping(value = "/{id}")
-    public @ResponseBody
-    Cat get(@PathVariable String id) {
+    public @ResponseBody Cat get(@PathVariable String id) {
         return service.get(id);
     }
 
     @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
-    public @ResponseBody
-    Cat
-    create(@RequestBody Cat cat) {
+	public @ResponseBody Cat create(@RequestBody Cat cat) {
         return service.create(cat);
     }
 }

--- a/src/main/java/cx/catapult/animals/web/CrustaceansController.java
+++ b/src/main/java/cx/catapult/animals/web/CrustaceansController.java
@@ -1,0 +1,28 @@
+package cx.catapult.animals.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import cx.catapult.animals.domain.Crustacean;
+import cx.catapult.animals.service.CrustaceansService;
+
+@RestController
+@RequestMapping(path = "/api/1/crustaceans", produces = MediaType.APPLICATION_JSON_VALUE)
+public class CrustaceansController {
+
+    @Autowired
+    private CrustaceansService service;
+
+    @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+	public @ResponseBody Crustacean create(@RequestBody Crustacean crustacean) {
+        return service.create(crustacean);
+    }
+}

--- a/src/main/java/cx/catapult/animals/web/CrustaceansController.java
+++ b/src/main/java/cx/catapult/animals/web/CrustaceansController.java
@@ -1,6 +1,7 @@
 package cx.catapult.animals.web;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.util.Collection;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -35,8 +37,7 @@ public class CrustaceansController {
     }
 
 	@GetMapping(value = "", produces = "application/json")
-	public @ResponseBody
-	Collection<Crustacean> all() {
+	public @ResponseBody Collection<Crustacean> all() {
 		return service.all();
 	}
 
@@ -45,12 +46,21 @@ public class CrustaceansController {
 		return service.get(id);
 	}
 
-	@DeleteMapping(value = "/{id}")
-	public ResponseEntity<Void> delete(@PathVariable String id) {
-		if (service.delete(id)) {
-			return new ResponseEntity<>(OK);
+	@PutMapping(value = "/{id}")
+	public ResponseEntity<Void> update(@PathVariable String id, @RequestBody Crustacean updated) {
+		if (service.update(id, updated) == null) {
+			return new ResponseEntity<>(NOT_FOUND);
 		}
 
-		return new ResponseEntity<>(NOT_FOUND);
+		return new ResponseEntity<>(NO_CONTENT);
+	}
+
+	@DeleteMapping(value = "/{id}")
+	public ResponseEntity<Void> delete(@PathVariable String id) {
+		if (!service.delete(id)) {
+			return new ResponseEntity<>(NOT_FOUND);
+		}
+
+		return new ResponseEntity<>(OK);
 	}
 }

--- a/src/main/java/cx/catapult/animals/web/CrustaceansController.java
+++ b/src/main/java/cx/catapult/animals/web/CrustaceansController.java
@@ -47,8 +47,8 @@ public class CrustaceansController {
 	}
 
 	@PutMapping(value = "/{id}")
-	public ResponseEntity<Void> update(@PathVariable String id, @RequestBody Crustacean updated) {
-		if (service.update(id, updated) == null) {
+	public ResponseEntity<Void> update(@PathVariable String id, @RequestBody Crustacean crustacean) {
+		if (service.update(id, crustacean) == null) {
 			return new ResponseEntity<>(NOT_FOUND);
 		}
 

--- a/src/main/java/cx/catapult/animals/web/CrustaceansController.java
+++ b/src/main/java/cx/catapult/animals/web/CrustaceansController.java
@@ -1,8 +1,11 @@
 package cx.catapult.animals.web;
 
+import java.util.Collection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,4 +28,15 @@ public class CrustaceansController {
 	public @ResponseBody Crustacean create(@RequestBody Crustacean crustacean) {
         return service.create(crustacean);
     }
+
+	@GetMapping(value = "", produces = "application/json")
+	public @ResponseBody
+	Collection<Crustacean> all() {
+		return service.all();
+	}
+
+	@GetMapping(value = "/{id}")
+	public @ResponseBody Crustacean get(@PathVariable String id) {
+		return service.get(id);
+	}
 }

--- a/src/main/java/cx/catapult/animals/web/CrustaceansController.java
+++ b/src/main/java/cx/catapult/animals/web/CrustaceansController.java
@@ -1,9 +1,14 @@
 package cx.catapult.animals.web;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
+
 import java.util.Collection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,5 +43,14 @@ public class CrustaceansController {
 	@GetMapping(value = "/{id}")
 	public @ResponseBody Crustacean get(@PathVariable String id) {
 		return service.get(id);
+	}
+
+	@DeleteMapping(value = "/{id}")
+	public ResponseEntity<Void> delete(@PathVariable String id) {
+		if (service.delete(id)) {
+			return new ResponseEntity<>(OK);
+		}
+
+		return new ResponseEntity<>(NOT_FOUND);
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 springdoc.api-docs.path=/api-docs
+
+spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/animals?createDatabaseIfNotExist=true
+spring.datasource.username=root
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true

--- a/src/test/java/cx/catapult/animals/AnimalsApiApplicationTests.java
+++ b/src/test/java/cx/catapult/animals/AnimalsApiApplicationTests.java
@@ -2,8 +2,10 @@ package cx.catapult.animals;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class AnimalsApiApplicationTests {
 
 	@Test

--- a/src/test/java/cx/catapult/animals/domain/CatTest.java
+++ b/src/test/java/cx/catapult/animals/domain/CatTest.java
@@ -1,0 +1,14 @@
+package cx.catapult.animals.domain;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class CatTest {
+
+	@Test
+	public void equalsContract() {
+		EqualsVerifier.simple().forClass(Cat.class).verify();
+	}
+
+}

--- a/src/test/java/cx/catapult/animals/domain/CrustaceanTest.java
+++ b/src/test/java/cx/catapult/animals/domain/CrustaceanTest.java
@@ -1,0 +1,14 @@
+package cx.catapult.animals.domain;
+
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class CrustaceanTest {
+
+	@Test
+	public void equalsContract() {
+		EqualsVerifier.simple().forClass(Crustacean.class).verify();
+	}
+
+}

--- a/src/test/java/cx/catapult/animals/service/AnimalsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/AnimalsServiceTest.java
@@ -1,0 +1,57 @@
+package cx.catapult.animals.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import cx.catapult.animals.domain.BaseAnimal;
+import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.domain.Crustacean;
+import cx.catapult.animals.repository.AnimalsRepository;
+
+/**
+ * Unit test for {@link AnimalsService}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class AnimalsServiceTest {
+
+	@Mock
+	AnimalsRepository<BaseAnimal> repository;
+
+	@InjectMocks
+	AnimalsService<BaseAnimal> service;
+
+	String name = "Colin";
+
+	Cat cat = new Cat(name, "Colin cat");
+	Crustacean crab = new Crustacean(name, "Colin crab");
+
+	@Test
+	public void getShouldWork() {
+		cat.setId(UUID.randomUUID().toString());
+		crab.setId(UUID.randomUUID().toString());
+		given(repository.findById(crab.getId())).willReturn(Optional.of(crab));
+
+		BaseAnimal actual = service.get(crab.getId());
+
+		assertThat(actual).isEqualTo(crab);
+	}
+
+	@Test
+	public void allShouldWork() {
+		given(repository.findByName(name)).willReturn(Arrays.asList(cat, crab));
+
+		Collection<? extends BaseAnimal> result = service.getByName(name);
+
+		assertThat(result.size()).isEqualTo(2);
+	}
+}

--- a/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
@@ -56,6 +56,29 @@ public class CatsServiceTest {
 	}
 
 	@Test
+	public void updateShouldWork() {
+		service.create(cat);
+		Cat updated = new Cat("Mog", "Mog the cat");
+
+		Cat result = service.update(cat.getId(), updated);
+
+		assertThat(result.getId()).isEqualTo(cat.getId());
+		assertThat(result.getName()).isEqualTo(cat.getName());
+		assertThat(result.getDescription()).isEqualTo(cat.getDescription());
+		assertThat(result.getGroup()).isEqualTo(cat.getGroup());
+	}
+
+	@Test
+	public void updateShouldWorkGivenUnknownCrab() {
+		service.create(cat);
+		Cat updated = new Cat("Molly", "Molly the unknown cat");
+
+		Cat result = service.update("unknown-id", updated);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
 	public void deleteShouldWork() {
 		service.create(cat);
 

--- a/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
@@ -1,17 +1,35 @@
 package cx.catapult.animals.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import java.util.Collections;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.repository.CatsRepository;
 
 /**
  * Unit test for {@link CatsService}.
  */
+@ExtendWith(MockitoExtension.class)
 public class CatsServiceTest {
 
-    CatsService service = new CatsService();
+	@Mock
+	CatsRepository repository;
+
+	@InjectMocks
+    CatsService service;
+
     Cat cat = new Cat("Tom", "Bob cat");
 
     @Test
@@ -27,13 +45,17 @@ public class CatsServiceTest {
         assertThat(actual.getName()).isEqualTo(thisCat.getName());
         assertThat(actual.getDescription()).isEqualTo(thisCat.getDescription());
         assertThat(actual.getGroup()).isEqualTo(thisCat.getGroup());
+		verify(repository).save(thisCat);
     }
 
     @Test
     public void allShouldWork() {
+		given(repository.getAll()).willReturn(Collections.singletonList(cat));
+
         service.create(cat);
 
         assertThat(service.all().size()).isEqualTo(1);
+		verify(repository).getAll();
     }
 
     @Test
@@ -50,15 +72,20 @@ public class CatsServiceTest {
 
 	@Test
 	public void getShouldWorkGivenUnknownCat() {
-		Cat actual = service.get("unknown-id");
+		String id = "unknown-id";
+		given(repository.findById(id)).willReturn(Optional.empty());
+
+		Cat actual = service.get(id);
 
 		assertThat(actual).isNull();
+		verify(repository).findById(id);
 	}
 
 	@Test
 	public void updateShouldWork() {
 		service.create(cat);
 		Cat updated = new Cat("Mog", "Mog the cat");
+		given(repository.findById(cat.getId())).willReturn(Optional.of(cat));
 
 		Cat result = service.update(cat.getId(), updated);
 
@@ -66,14 +93,17 @@ public class CatsServiceTest {
 		assertThat(result.getName()).isEqualTo(cat.getName());
 		assertThat(result.getDescription()).isEqualTo(cat.getDescription());
 		assertThat(result.getGroup()).isEqualTo(cat.getGroup());
+		verify(repository, times(2)).save(result);
 	}
 
 	@Test
 	public void updateShouldWorkGivenUnknownCrab() {
 		service.create(cat);
+		String unknownId = "unknown-id";
+		given(repository.findById(unknownId)).willReturn(Optional.empty());
 		Cat updated = new Cat("Molly", "Molly the unknown cat");
 
-		Cat result = service.update("unknown-id", updated);
+		Cat result = service.update(unknownId, updated);
 
 		assertThat(result).isNull();
 	}
@@ -85,11 +115,15 @@ public class CatsServiceTest {
 		boolean deleted = service.delete(cat.getId());
 
 		assertThat(deleted).isTrue();
+		verify(repository).deleteById(cat.getId());
 	}
 
 	@Test
 	public void deleteShouldWorkGivenUnknownCat() {
-		boolean deleted = service.delete("unknown-id");
+		String id = "unknown-id";
+		doThrow(new EmptyResultDataAccessException(1)).when(repository).deleteById(id);
+
+		boolean deleted = service.delete(id);
 
 		assertThat(deleted).isFalse();
 	}

--- a/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
@@ -1,21 +1,28 @@
 package cx.catapult.animals.service;
 
-import cx.catapult.animals.domain.Cat;
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
+
+import cx.catapult.animals.domain.Cat;
+
+/**
+ * Unit test for {@link CatsService}.
+ */
 public class CatsServiceTest {
 
     CatsService service = new CatsService();
     Cat cat = new Cat("Tom", "Bob cat");
 
     @Test
-    public void createShouldWork() throws Exception {
+    public void createShouldWork() {
         Cat thisCat = new Cat();
         thisCat.setName("Jerry");
         thisCat.setDescription("Mouse Cat");
+
+
         Cat actual = service.create(thisCat);
+
         assertThat(actual).isEqualTo(thisCat);
         assertThat(actual.getName()).isEqualTo(thisCat.getName());
         assertThat(actual.getDescription()).isEqualTo(thisCat.getDescription());
@@ -23,15 +30,18 @@ public class CatsServiceTest {
     }
 
     @Test
-    public void allShouldWork() throws Exception {
+    public void allShouldWork() {
         service.create(cat);
+
         assertThat(service.all().size()).isEqualTo(1);
     }
 
     @Test
-    public void getShouldWork() throws Exception {
+    public void getShouldWork() {
         service.create(cat);
+
         Cat actual = service.get(cat.getId());
+
         assertThat(actual).isEqualTo(cat);
         assertThat(actual.getName()).isEqualTo(cat.getName());
         assertThat(actual.getDescription()).isEqualTo(cat.getDescription());

--- a/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
@@ -47,4 +47,27 @@ public class CatsServiceTest {
         assertThat(actual.getDescription()).isEqualTo(cat.getDescription());
         assertThat(actual.getGroup()).isEqualTo(cat.getGroup());
     }
+
+	@Test
+	public void getShouldWorkGivenUnknownCat() {
+		Cat actual = service.get("unknown-id");
+
+		assertThat(actual).isNull();
+	}
+
+	@Test
+	public void deleteShouldWork() {
+		service.create(cat);
+
+		boolean deleted = service.delete(cat.getId());
+
+		assertThat(deleted).isTrue();
+	}
+
+	@Test
+	public void deleteShouldWorkGivenUnknownCat() {
+		boolean deleted = service.delete("unknown-id");
+
+		assertThat(deleted).isFalse();
+	}
 }

--- a/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
@@ -1,0 +1,29 @@
+package cx.catapult.animals.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import cx.catapult.animals.domain.Crustacean;
+
+/**
+ * Unit test for {@link CrustaceansService}.
+ */
+public class CrustaceansServiceTest {
+
+	CrustaceansService service = new CrustaceansService();
+
+	@Test
+	public void createShouldWork() {
+		Crustacean thisCrab = new Crustacean();
+		thisCrab.setName("Crabby");
+		thisCrab.setDescription("Crabby the Crab");
+
+		Crustacean actual = service.create(thisCrab);
+
+		assertThat(actual).isEqualTo(thisCrab);
+		assertThat(actual.getName()).isEqualTo(thisCrab.getName());
+		assertThat(actual.getDescription()).isEqualTo(thisCrab.getDescription());
+		assertThat(actual.getGroup()).isEqualTo(thisCrab.getGroup());
+	}
+}

--- a/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
@@ -55,6 +55,29 @@ public class CrustaceansServiceTest {
 	}
 
 	@Test
+	public void updateShouldWork() {
+		service.create(crab);
+		Crustacean updated = new Crustacean("Colin", "Colin the crab");
+
+		Crustacean result = service.update(crab.getId(), updated);
+
+		assertThat(result.getId()).isEqualTo(crab.getId());
+		assertThat(result.getName()).isEqualTo(crab.getName());
+		assertThat(result.getDescription()).isEqualTo(crab.getDescription());
+		assertThat(result.getGroup()).isEqualTo(crab.getGroup());
+	}
+
+	@Test
+	public void updateShouldWorkGivenUnknownCrab() {
+		service.create(crab);
+		Crustacean updated = new Crustacean("Colin", "Colin the unknown crab");
+
+		Crustacean result = service.update("unknown-id", updated);
+
+		assertThat(result).isNull();
+	}
+
+	@Test
 	public void deleteShouldWork() {
 		service.create(crab);
 

--- a/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
@@ -12,6 +12,7 @@ import cx.catapult.animals.domain.Crustacean;
 public class CrustaceansServiceTest {
 
 	CrustaceansService service = new CrustaceansService();
+	Crustacean crab = new Crustacean("Crusty", "Crusty the crab");
 
 	@Test
 	public void createShouldWork() {
@@ -25,5 +26,24 @@ public class CrustaceansServiceTest {
 		assertThat(actual.getName()).isEqualTo(thisCrab.getName());
 		assertThat(actual.getDescription()).isEqualTo(thisCrab.getDescription());
 		assertThat(actual.getGroup()).isEqualTo(thisCrab.getGroup());
+	}
+
+	@Test
+	public void allShouldWork() {
+		service.create(crab);
+
+		assertThat(service.all().size()).isEqualTo(1);
+	}
+
+	@Test
+	public void getShouldWork() {
+		service.create(crab);
+
+		Crustacean actual = service.get(crab.getId());
+
+		assertThat(actual).isEqualTo(crab);
+		assertThat(actual.getName()).isEqualTo(crab.getName());
+		assertThat(actual.getDescription()).isEqualTo(crab.getDescription());
+		assertThat(actual.getGroup()).isEqualTo(crab.getGroup());
 	}
 }

--- a/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
@@ -1,17 +1,35 @@
 package cx.catapult.animals.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import java.util.Collections;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
 
 import cx.catapult.animals.domain.Crustacean;
+import cx.catapult.animals.repository.CrustaceansRepository;
 
 /**
  * Unit test for {@link CrustaceansService}.
  */
+@ExtendWith(MockitoExtension.class)
 public class CrustaceansServiceTest {
 
-	CrustaceansService service = new CrustaceansService();
+	@Mock
+	CrustaceansRepository repository;
+
+	@InjectMocks
+	CrustaceansService service;
+
 	Crustacean crab = new Crustacean("Crusty", "Crusty the crab");
 
 	@Test
@@ -26,13 +44,16 @@ public class CrustaceansServiceTest {
 		assertThat(actual.getName()).isEqualTo(thisCrab.getName());
 		assertThat(actual.getDescription()).isEqualTo(thisCrab.getDescription());
 		assertThat(actual.getGroup()).isEqualTo(thisCrab.getGroup());
+		verify(repository).save(thisCrab);
 	}
 
 	@Test
 	public void allShouldWork() {
 		service.create(crab);
+		given(repository.getAll()).willReturn(Collections.singletonList(crab));
 
 		assertThat(service.all().size()).isEqualTo(1);
+		verify(repository).getAll();
 	}
 
 	@Test
@@ -49,15 +70,20 @@ public class CrustaceansServiceTest {
 
 	@Test
 	public void getShouldWorkGivenUnknownCrustacean() {
-		Crustacean actual = service.get("unknown-id");
+		String id = "unknown-id";
+		given(repository.findById(id)).willReturn(Optional.empty());
+
+		Crustacean actual = service.get(id);
 
 		assertThat(actual).isNull();
+		verify(repository).findById(id);
 	}
 
 	@Test
 	public void updateShouldWork() {
 		service.create(crab);
 		Crustacean updated = new Crustacean("Colin", "Colin the crab");
+		given(repository.findById(crab.getId())).willReturn(Optional.of(crab));
 
 		Crustacean result = service.update(crab.getId(), updated);
 
@@ -65,11 +91,14 @@ public class CrustaceansServiceTest {
 		assertThat(result.getName()).isEqualTo(crab.getName());
 		assertThat(result.getDescription()).isEqualTo(crab.getDescription());
 		assertThat(result.getGroup()).isEqualTo(crab.getGroup());
+		verify(repository, times(2)).save(result);
 	}
 
 	@Test
 	public void updateShouldWorkGivenUnknownCrab() {
 		service.create(crab);
+		String unknownId = "unknown-id";
+		given(repository.findById(unknownId)).willReturn(Optional.empty());
 		Crustacean updated = new Crustacean("Colin", "Colin the unknown crab");
 
 		Crustacean result = service.update("unknown-id", updated);
@@ -84,11 +113,15 @@ public class CrustaceansServiceTest {
 		boolean deleted = service.delete(crab.getId());
 
 		assertThat(deleted).isTrue();
+		verify(repository).deleteById(crab.getId());
 	}
 
 	@Test
 	public void deleteShouldWorkGivenUnknownCrustacean() {
-		boolean deleted = service.delete("unknown-id");
+		String id = "unknown-id";
+		doThrow(new EmptyResultDataAccessException(1)).when(repository).deleteById(id);
+
+		boolean deleted = service.delete(id);
 
 		assertThat(deleted).isFalse();
 	}

--- a/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CrustaceansServiceTest.java
@@ -46,4 +46,27 @@ public class CrustaceansServiceTest {
 		assertThat(actual.getDescription()).isEqualTo(crab.getDescription());
 		assertThat(actual.getGroup()).isEqualTo(crab.getGroup());
 	}
+
+	@Test
+	public void getShouldWorkGivenUnknownCrustacean() {
+		Crustacean actual = service.get("unknown-id");
+
+		assertThat(actual).isNull();
+	}
+
+	@Test
+	public void deleteShouldWork() {
+		service.create(crab);
+
+		boolean deleted = service.delete(crab.getId());
+
+		assertThat(deleted).isTrue();
+	}
+
+	@Test
+	public void deleteShouldWorkGivenUnknownCrustacean() {
+		boolean deleted = service.delete("unknown-id");
+
+		assertThat(deleted).isFalse();
+	}
 }

--- a/src/test/java/cx/catapult/animals/web/AnimalsControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/AnimalsControllerIT.java
@@ -1,0 +1,80 @@
+package cx.catapult.animals.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.GET;
+
+import java.net.URL;
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import cx.catapult.animals.domain.BaseAnimal;
+import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.domain.Crustacean;
+
+/**
+ * A Spring Boot integration test for the {@link AnimalsController}.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class AnimalsControllerIT {
+    @LocalServerPort
+    private int port;
+
+    private URL base;
+
+    @Autowired
+    private TestRestTemplate template;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        this.base = new URL("http://localhost:" + port + "/api/1/animals");
+    }
+
+	@Test
+	public void getShouldWork() {
+		Cat created = createCat("Cat 1");
+		String url = base.toString() + "/" + created.getId();
+
+		ResponseEntity<? extends BaseAnimal> response = template.getForEntity(url, Cat.class);
+
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getName()).isEqualTo("Cat 1");
+	}
+
+    @Test
+    public <T extends BaseAnimal> void allShouldWork() {
+		String name = "Animal 1";
+		createCat(name);
+		createCrustacean(name);
+		String url = base.toString() + "?name=" + name;
+		ParameterizedTypeReference<Collection<? extends BaseAnimal>> responseType = new ParameterizedTypeReference<Collection<? extends BaseAnimal>>() {};
+
+		Collection<? extends BaseAnimal> animals = template.exchange(url, GET, null, responseType).getBody();
+
+        assertThat(animals.size()).isEqualTo(2);
+    }
+
+	Cat createCat(String name) {
+		String url = "http://localhost:" + port + "/api/1/cats";
+		Cat created = template.postForObject(url, new Cat(name, name), Cat.class);
+		assertThat(created.getId()).isNotEmpty();
+		assertThat(created.getName()).isEqualTo(name);
+		return created;
+	}
+
+	Crustacean createCrustacean(String name) {
+		String url = "http://localhost:" + port + "/api/1/crustaceans";
+		Crustacean created = template.postForObject(url, new Crustacean(name, name), Crustacean.class);
+		assertThat(created.getId()).isNotEmpty();
+		assertThat(created.getName()).isEqualTo(name);
+		return created;
+	}
+}

--- a/src/test/java/cx/catapult/animals/web/AnimalsControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/AnimalsControllerTest.java
@@ -1,0 +1,44 @@
+package cx.catapult.animals.web;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import cx.catapult.animals.domain.BaseAnimal;
+import cx.catapult.animals.service.AnimalsService;
+
+/**
+ * A {@link SpringBootTest} for the {@link AnimalsController}.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class AnimalsControllerTest {
+	private static final String URI_PATH = "/api/1/animals";
+
+	@Autowired
+	private MockMvc mvc;
+
+	@MockBean
+	private AnimalsService<BaseAnimal> service;
+
+	@Test
+	public void get() throws Exception {
+		mvc.perform(MockMvcRequestBuilders.get(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void getByName() throws Exception {
+		mvc.perform(MockMvcRequestBuilders.get(URI_PATH + "?name=Tom").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+}

--- a/src/test/java/cx/catapult/animals/web/CatsControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerIT.java
@@ -1,7 +1,10 @@
 package cx.catapult.animals.web;
 
 
-import cx.catapult.animals.domain.Cat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import java.util.Collection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,14 +14,12 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.net.URL;
-import java.util.Collection;
+import cx.catapult.animals.domain.Cat;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-
+/**
+ * A Spring Boot integration test for the {@link CatsController}.
+ */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-
 public class CatsControllerIT {
     @LocalServerPort
     private int port;
@@ -36,7 +37,7 @@ public class CatsControllerIT {
     }
 
     @Test
-    public void createShouldWork() throws Exception {
+    public void createShouldWork() {
         ResponseEntity<Cat> response = template.postForEntity(base.toString(), cat, Cat.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(response.getBody().getId()).isNotEmpty();
@@ -46,13 +47,13 @@ public class CatsControllerIT {
     }
 
     @Test
-    public void allShouldWork() throws Exception {
+    public void allShouldWork() {
         Collection items = template.getForObject(base.toString(), Collection.class);
         assertThat(items.size()).isGreaterThanOrEqualTo(7);
     }
 
     @Test
-    public void getShouldWork() throws Exception {
+    public void getShouldWork() {
         Cat created = create("Test 1");
         ResponseEntity<String> response = template.getForEntity(base.toString() + "/" + created.getId(), String.class);
         assertThat(response.getBody()).isNotEmpty();

--- a/src/test/java/cx/catapult/animals/web/CatsControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerIT.java
@@ -17,6 +17,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 
 import cx.catapult.animals.domain.Cat;
 
@@ -24,6 +25,7 @@ import cx.catapult.animals.domain.Cat;
  * A Spring Boot integration test for the {@link CatsController}.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
 public class CatsControllerIT {
     @LocalServerPort
     private int port;

--- a/src/test/java/cx/catapult/animals/web/CatsControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerIT.java
@@ -2,6 +2,9 @@ package cx.catapult.animals.web;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import java.net.URL;
 import java.util.Collection;
@@ -11,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -59,10 +63,32 @@ public class CatsControllerIT {
         assertThat(response.getBody()).isNotEmpty();
     }
 
-    Cat create(String name) {
-        Cat created = template.postForObject(base.toString(), new Cat(name, name), Cat.class);
-        assertThat(created.getId()).isNotEmpty();
-        assertThat(created.getName()).isEqualTo(name);
-        return created;
-    }
+	@Test
+	public void updateShouldWork() {
+		Cat created = create("Initial Cat");
+		String url = base.toString() + "/" + created.getId();
+		Cat updated = new Cat("Unknown Cat", "Unknown Cat");
+		HttpEntity<Cat> requestEntity = new HttpEntity<>(updated);
+
+		ResponseEntity<Void> response = template.exchange(url, PUT, requestEntity, Void.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(NO_CONTENT);
+	}
+
+	@Test
+	public void updateShouldWorkGivenUnknownId() {
+		Cat unknownCrab = new Cat("Unknown Cat", "Unknown Cat");
+		String url = base.toString() + "/unknownId";
+
+		ResponseEntity<Void> response = template.exchange(url, PUT, new HttpEntity<>(unknownCrab), Void.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+	}
+
+	Cat create(String name) {
+		Cat created = template.postForObject(base.toString(), new Cat(name, name), Cat.class);
+		assertThat(created.getId()).isNotEmpty();
+		assertThat(created.getName()).isEqualTo(name);
+		return created;
+	}
 }

--- a/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -19,6 +20,7 @@ import cx.catapult.animals.service.CatsService;
  * A {@link SpringBootTest} for the {@link CrustaceansController}.
  */
 @SpringBootTest
+@ActiveProfiles("test")
 @AutoConfigureMockMvc
 public class CatsControllerTest {
 

--- a/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
@@ -1,6 +1,7 @@
 package cx.catapult.animals.web;
 
-import cx.catapult.animals.domain.Cat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -9,10 +10,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
+/**
+ * A {@link SpringBootTest} for the {@link CrustaceansController}.
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
 public class CatsControllerTest {
@@ -20,7 +20,6 @@ public class CatsControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    private Cat cat = new Cat("Tom", "Bob cat");
     private String json = "{ \"name\": \"Tom\", \"description\": \"Bob cat\" }";
 
     @Test

--- a/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
@@ -1,14 +1,19 @@
 package cx.catapult.animals.web;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.service.CatsService;
 
 /**
  * A {@link SpringBootTest} for the {@link CrustaceansController}.
@@ -21,6 +26,9 @@ public class CatsControllerTest {
 
 	@Autowired
     private MockMvc mvc;
+
+	@MockBean
+	private CatsService service;
 
     private String json = "{ \"name\": \"Tom\", \"description\": \"Bob cat\" }";
 
@@ -41,4 +49,28 @@ public class CatsControllerTest {
         mvc.perform(MockMvcRequestBuilders.post(URI_PATH).content(json).contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isCreated());
     }
+
+	@Test
+	public void update() throws Exception {
+		Cat updatedCat = new Cat("Scratchy", "Scratchy cat");
+		String updatedJson = "{ \"name\": \"Scratchy\", \"description\": \"Scratchy cat\" }";
+		given(service.update("123", updatedCat)).willReturn(updatedCat);
+
+		mvc.perform(MockMvcRequestBuilders.put(URI_PATH + "/123")
+				.content(updatedJson)
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+				.andExpect(status().isNoContent());
+	}
+
+	@Test
+	public void updateUnknownCat() throws Exception {
+		Cat updatedCat = new Cat("Scratchy", "Scratchy cat");
+		String updatedJson = "{ \"name\": \"Scratchy\", \"description\": \"Scratchy cat\" }";
+		given(service.update("123", updatedCat)).willReturn(null);
+
+		mvc.perform(MockMvcRequestBuilders.put(URI_PATH + "/123")
+				.content(updatedJson)
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+				.andExpect(status().isNotFound());
+	}
 }

--- a/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
@@ -17,7 +17,7 @@ import cx.catapult.animals.domain.Cat;
 import cx.catapult.animals.service.CatsService;
 
 /**
- * A {@link SpringBootTest} for the {@link CrustaceansController}.
+ * A {@link SpringBootTest} for the {@link CatsController}.
  */
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
@@ -17,26 +17,28 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @AutoConfigureMockMvc
 public class CatsControllerTest {
 
-    @Autowired
+	private static final String URI_PATH = "/api/1/cats";
+
+	@Autowired
     private MockMvc mvc;
 
     private String json = "{ \"name\": \"Tom\", \"description\": \"Bob cat\" }";
 
     @Test
     public void all() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get("/api/1/cats").accept(MediaType.APPLICATION_JSON))
+        mvc.perform(MockMvcRequestBuilders.get(URI_PATH).accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 
     @Test
     public void get() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.get("/api/1/cats/123").accept(MediaType.APPLICATION_JSON))
+        mvc.perform(MockMvcRequestBuilders.get(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 
     @Test
     public void create() throws Exception {
-        mvc.perform(MockMvcRequestBuilders.post("/api/1/cats").content(json).contentType(MediaType.APPLICATION_JSON_VALUE))
+        mvc.perform(MockMvcRequestBuilders.post(URI_PATH).content(json).contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isCreated());
     }
 }

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerIT.java
@@ -3,6 +3,7 @@ package cx.catapult.animals.web;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URL;
+import java.util.Collection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,4 +45,24 @@ public class CrustaceansControllerIT {
         assertThat(response.getBody().getDescription()).isEqualTo(crustacean.getDescription());
         assertThat(response.getBody().getGroup()).isEqualTo(crustacean.getGroup());
     }
+
+	@Test
+	public void allShouldWork() {
+		Collection items = template.getForObject(base.toString(), Collection.class);
+		assertThat(items.size()).isGreaterThanOrEqualTo(3);
+	}
+
+	@Test
+	public void getShouldWork() {
+		Crustacean created = create("Test 1");
+		ResponseEntity<String> response = template.getForEntity(base.toString() + "/" + created.getId(), String.class);
+		assertThat(response.getBody()).isNotEmpty();
+	}
+
+	Crustacean create(String name) {
+		Crustacean created = template.postForObject(base.toString(), new Crustacean(name, name), Crustacean.class);
+		assertThat(created.getId()).isNotEmpty();
+		assertThat(created.getName()).isEqualTo(name);
+		return created;
+	}
 }

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerIT.java
@@ -2,8 +2,10 @@ package cx.catapult.animals.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.PUT;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.net.URL;
@@ -14,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 
 import cx.catapult.animals.domain.Crustacean;
@@ -60,10 +63,33 @@ public class CrustaceansControllerIT {
 	public void getShouldWork() {
 		Crustacean created = create("Test 1");
 
-		ResponseEntity<String> response = template.getForEntity(base.toString() + "/" + created.getId(), String.class);
+		ResponseEntity<Crustacean> response = template.getForEntity(base.toString() + "/" + created.getId(), Crustacean.class);
 
 		assertThat(response.getStatusCode()).isEqualTo(OK);
-		assertThat(response.getBody()).isNotEmpty();
+		assertThat(response.getBody()).isNotNull();
+		assertThat(response.getBody().getName()).isEqualTo("Test 1");
+	}
+
+	@Test
+	public void updateShouldWork() {
+		Crustacean created = create("Test 1");
+		String url = base.toString() + "/" + created.getId();
+		Crustacean updated = new Crustacean("Updated", "Updated");
+		HttpEntity<Crustacean> requestEntity = new HttpEntity<>(updated);
+
+		ResponseEntity<Void> response = template.exchange(url, PUT, requestEntity, Void.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(NO_CONTENT);
+	}
+
+	@Test
+	public void updateShouldWorkGivenUnknownId() {
+		Crustacean unknownCrab = new Crustacean("Unknown Crab", "Unknown Crab");
+		String url = base.toString() + "/unknownId";
+
+		ResponseEntity<Void> response = template.exchange(url, PUT, new HttpEntity<>(unknownCrab), Void.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
 	}
 
 	@Test

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerIT.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 
 import cx.catapult.animals.domain.Crustacean;
 
@@ -25,6 +26,7 @@ import cx.catapult.animals.domain.Crustacean;
  * A Spring Boot integration test for the {@link CrustaceansController}.
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
 public class CrustaceansControllerIT {
     @LocalServerPort
     private int port;

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerIT.java
@@ -1,0 +1,47 @@
+package cx.catapult.animals.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import cx.catapult.animals.domain.Crustacean;
+
+/**
+ * A Spring Boot integration test for the {@link CrustaceansController}.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CrustaceansControllerIT {
+    @LocalServerPort
+    private int port;
+
+    private URL base;
+
+    private Crustacean crustacean = new Crustacean("Crabby", "Crabby the crab");
+
+    @Autowired
+    private TestRestTemplate template;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        this.base = new URL("http://localhost:" + port + "/api/1/crustaceans");
+    }
+
+    @Test
+    public void createShouldWork() {
+        ResponseEntity<Crustacean> response = template.postForEntity(base.toString(), crustacean, Crustacean.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody().getId()).isNotEmpty();
+        assertThat(response.getBody().getName()).isEqualTo(crustacean.getName());
+        assertThat(response.getBody().getDescription()).isEqualTo(crustacean.getDescription());
+        assertThat(response.getBody().getGroup()).isEqualTo(crustacean.getGroup());
+    }
+}

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -19,6 +20,7 @@ import cx.catapult.animals.service.CrustaceansService;
  * A {@link SpringBootTest} for the {@link CrustaceansController}.
  */
 @SpringBootTest
+@ActiveProfiles("test")
 @AutoConfigureMockMvc
 public class CrustaceansControllerTest {
 

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
@@ -67,10 +67,30 @@ public class CrustaceansControllerTest {
 	}
 
 	@Test
+	public void updateUnknownCrustacean() throws Exception {
+		Crustacean updatedCrustacean = new Crustacean("Colin", "Colin the crab");
+		String updatedJson = "{ \"name\": \"Colin\", \"description\": \"Colin the crab\" }";
+		given(service.update("123", updatedCrustacean)).willReturn(null);
+
+		mvc.perform(MockMvcRequestBuilders.put(URI_PATH + "/123")
+				.content(updatedJson)
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+				.andExpect(status().isNotFound());
+	}
+
+	@Test
 	public void delete() throws Exception {
 		given(service.delete("123")).willReturn(true);
 
 		mvc.perform(MockMvcRequestBuilders.delete(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void deleteUnknownCrustacean() throws Exception {
+		given(service.delete("123")).willReturn(false);
+
+		mvc.perform(MockMvcRequestBuilders.delete(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound());
 	}
 }

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
@@ -1,14 +1,18 @@
 package cx.catapult.animals.web;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import cx.catapult.animals.service.CrustaceansService;
 
 /**
  * A {@link SpringBootTest} for the {@link CrustaceansController}.
@@ -21,6 +25,9 @@ public class CrustaceansControllerTest {
 
 	@Autowired
 	private MockMvc mvc;
+
+	@MockBean
+	private CrustaceansService service;
 
 	private String json = "{ \"name\": \"Crabby\", \"description\": \"Crabby the crab\" }";
 
@@ -41,6 +48,13 @@ public class CrustaceansControllerTest {
 	@Test
 	public void get() throws Exception {
 		mvc.perform(MockMvcRequestBuilders.get(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void delete() throws Exception {
+		given(service.delete("123")).willReturn(true);
+		mvc.perform(MockMvcRequestBuilders.delete(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 	}
 }

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
@@ -1,0 +1,33 @@
+package cx.catapult.animals.web;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+/**
+ * A {@link SpringBootTest} for the {@link CrustaceansController}.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CrustaceansControllerTest {
+
+	@Autowired
+	private MockMvc mvc;
+
+	private String json = "{ \"name\": \"Crabby\", \"description\": \"Crabby the crab\" }";
+
+	@Test
+	public void create() throws Exception {
+		mvc.perform(MockMvcRequestBuilders.post("/api/1/crustaceans")
+				.content(json)
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+				.andExpect(status().isCreated());
+	}
+
+}

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import cx.catapult.animals.domain.Crustacean;
 import cx.catapult.animals.service.CrustaceansService;
 
 /**
@@ -41,19 +42,34 @@ public class CrustaceansControllerTest {
 
 	@Test
 	public void all() throws Exception {
-		mvc.perform(MockMvcRequestBuilders.get(URI_PATH).accept(MediaType.APPLICATION_JSON))
+		mvc.perform(MockMvcRequestBuilders.get(URI_PATH)
+				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 	}
 
 	@Test
 	public void get() throws Exception {
-		mvc.perform(MockMvcRequestBuilders.get(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
+		mvc.perform(MockMvcRequestBuilders.get(URI_PATH + "/123")
+				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void update() throws Exception {
+		Crustacean updatedCrustacean = new Crustacean("Colin", "Colin the crab");
+		String updatedJson = "{ \"name\": \"Colin\", \"description\": \"Colin the crab\" }";
+		given(service.update("123", updatedCrustacean)).willReturn(updatedCrustacean);
+
+		mvc.perform(MockMvcRequestBuilders.put(URI_PATH + "/123")
+				.content(updatedJson)
+				.contentType(MediaType.APPLICATION_JSON_VALUE))
+				.andExpect(status().isNoContent());
 	}
 
 	@Test
 	public void delete() throws Exception {
 		given(service.delete("123")).willReturn(true);
+
 		mvc.perform(MockMvcRequestBuilders.delete(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 	}

--- a/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CrustaceansControllerTest.java
@@ -17,6 +17,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @AutoConfigureMockMvc
 public class CrustaceansControllerTest {
 
+	private static final String URI_PATH = "/api/1/crustaceans";
+
 	@Autowired
 	private MockMvc mvc;
 
@@ -24,10 +26,21 @@ public class CrustaceansControllerTest {
 
 	@Test
 	public void create() throws Exception {
-		mvc.perform(MockMvcRequestBuilders.post("/api/1/crustaceans")
+		mvc.perform(MockMvcRequestBuilders.post(URI_PATH)
 				.content(json)
 				.contentType(MediaType.APPLICATION_JSON_VALUE))
 				.andExpect(status().isCreated());
 	}
 
+	@Test
+	public void all() throws Exception {
+		mvc.perform(MockMvcRequestBuilders.get(URI_PATH).accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void get() throws Exception {
+		mvc.perform(MockMvcRequestBuilders.get(URI_PATH + "/123").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true


### PR DESCRIPTION
### Developer Exercise - Animals API

- Added `Crustacean` with store, view, delete and update functions.
- Introduced `PersistenceService` which extends `BaseService`. My interpretation of the requirements is that the "in-memory" functionality should still be used, though it's currently providing a brittle and poor quality cache implementation.
- Using H2 for `SpringBootTests` and MySQL in the main application's configuration, plus the docker-compose setup.
- The error handling (e.g. for null/missing entities) is virtually non existent. I've added some, but it's very forgiving. Normally I would add throw exceptions where required and use Spring's global `ExceptionHandler` for dealing with them.