### PR TITLE
Add CRUD operations to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**
 !**/src/test/**
+bin/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/cx/catapult/animals/exception/AnimalNotFoundException.java
+++ b/src/main/java/cx/catapult/animals/exception/AnimalNotFoundException.java
@@ -1,0 +1,7 @@
+package cx.catapult.animals.exception;
+
+public class AnimalNotFoundException extends RuntimeException {
+    public AnimalNotFoundException(String id) {
+        super("Animal not found with id: " + id);
+    }
+}

--- a/src/main/java/cx/catapult/animals/exception/GlobalExceptionHandler.java
+++ b/src/main/java/cx/catapult/animals/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package cx.catapult.animals.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.server.ResponseStatusException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<String> handleResponseStatusException(ResponseStatusException ex) {
+        HttpStatus status = ex.getStatus();
+        String message = ex.getMessage();
+        return new ResponseEntity<>(message, status);
+    }
+	
+}

--- a/src/main/java/cx/catapult/animals/service/BaseService.java
+++ b/src/main/java/cx/catapult/animals/service/BaseService.java
@@ -1,33 +1,48 @@
 package cx.catapult.animals.service;
 
 import cx.catapult.animals.domain.Animal;
+import cx.catapult.animals.exception.AnimalNotFoundException;
 
 import java.util.*;
 
 public abstract class BaseService<T extends Animal> implements Service<T> {
 
-    private HashMap<String, T> items = new HashMap<>();
+	private HashMap<String, T> items = new HashMap<>();
 
-    @Override
-    public Collection<T> all() {
-        return items.values();
-    }
+	@Override
+	public Collection<T> all() {
+		return items.values();
+	}
 
-    @Override
-    public T create(T animal) {
-        String id = UUID.randomUUID().toString();
-        animal.setId(id);
-        items.put(id, animal);
-        return animal;
-    }
+	@Override
+	public T create(T animal) {
+		String id = UUID.randomUUID().toString();
+		String name = animal.getName();
+		String description = animal.getDescription();
 
-    @Override
-    public T get(String id) {
-        return items.get(id);
-    }
-    
-    @Override
-    public void delete(String id) {
-    	items.remove(id);
-    }
+		if (name.isBlank() || description.isBlank()) {
+			throw new IllegalArgumentException("Name and description are required fields");
+		}
+
+		animal.setId(id);
+		items.put(id, animal);
+		return animal;
+	}
+
+	@Override
+	public T get(String id) {
+		T animal = items.get(id);
+		if (animal == null) {
+			throw new AnimalNotFoundException(id);
+		}
+		return animal;
+	}
+
+	@Override
+	public void delete(String id) {
+		T animal = items.remove(id);
+		if (animal == null) {
+			throw new AnimalNotFoundException(id);
+		}
+	}
 }

--- a/src/main/java/cx/catapult/animals/service/BaseService.java
+++ b/src/main/java/cx/catapult/animals/service/BaseService.java
@@ -25,4 +25,9 @@ public abstract class BaseService<T extends Animal> implements Service<T> {
     public T get(String id) {
         return items.get(id);
     }
+    
+    @Override
+    public void delete(String id) {
+    	items.remove(id);
+    }
 }

--- a/src/main/java/cx/catapult/animals/service/BaseService.java
+++ b/src/main/java/cx/catapult/animals/service/BaseService.java
@@ -1,9 +1,12 @@
 package cx.catapult.animals.service;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import cx.catapult.animals.domain.Animal;
 import cx.catapult.animals.exception.AnimalNotFoundException;
-
-import java.util.*;
 
 public abstract class BaseService<T extends Animal> implements Service<T> {
 
@@ -45,4 +48,36 @@ public abstract class BaseService<T extends Animal> implements Service<T> {
 			throw new AnimalNotFoundException(id);
 		}
 	}
+	
+	@Override
+	public T update(String id, T animal) {
+	    T existingAnimal = items.get(id);
+	    if (existingAnimal == null) {
+	        throw new AnimalNotFoundException(id);
+	    }
+
+
+	    animal.setId(existingAnimal.getId());
+	    items.put(id, animal);
+	    
+	    return animal;
+	}
+	
+	@Override
+    public Collection<T> getByName(String name) {
+        return items.values()
+                .stream()
+                .filter(a -> a.getName().equals(name))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<T> getByDescription(String description) {
+        return items.values()
+                .stream()
+                .filter(a -> a.getDescription().equals(description))
+                .collect(Collectors.toList());
+    }
+	
+	
 }

--- a/src/main/java/cx/catapult/animals/service/Service.java
+++ b/src/main/java/cx/catapult/animals/service/Service.java
@@ -11,5 +11,7 @@ public interface Service<T extends Animal> {
     T create(T animal);
 
     public T get(String id);
+    
+    void delete(String id);
 
 }

--- a/src/main/java/cx/catapult/animals/service/Service.java
+++ b/src/main/java/cx/catapult/animals/service/Service.java
@@ -13,5 +13,11 @@ public interface Service<T extends Animal> {
     public T get(String id);
     
     void delete(String id);
+    
+    public T update(String id, T animal);
+    
+    public Collection<T> getByName(String name);
+    
+    public Collection<T> getByDescription(String description);
 
 }

--- a/src/main/java/cx/catapult/animals/web/CatsController.java
+++ b/src/main/java/cx/catapult/animals/web/CatsController.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +25,7 @@ import cx.catapult.animals.service.CatsService;
 
 @RestController
 @RequestMapping(path = "/api/1/cats", produces = MediaType.APPLICATION_JSON_VALUE)
+@CrossOrigin(origins = "http://localhost:3000")
 public class CatsController {
 
 	@Autowired

--- a/src/main/java/cx/catapult/animals/web/CatsController.java
+++ b/src/main/java/cx/catapult/animals/web/CatsController.java
@@ -1,13 +1,26 @@
 package cx.catapult.animals.web;
 
-import cx.catapult.animals.domain.Cat;
-import cx.catapult.animals.service.CatsService;
+import java.util.Collection;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
-import java.util.Collection;
+import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.exception.AnimalNotFoundException;
+import cx.catapult.animals.service.CatsService;
 
 @RestController
 @RequestMapping(path = "/api/1/cats", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -25,7 +38,28 @@ public class CatsController {
     @GetMapping(value = "/{id}")
     public @ResponseBody
     Cat get(@PathVariable String id) {
-        return service.get(id);
+    	try {
+            return service.get(id);
+        } catch (AnimalNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+    
+    @GetMapping(value = "/search", produces = "application/json")
+    public @ResponseBody Collection<Cat> search(
+            @RequestParam(name = "name", required = false) String name,
+            @RequestParam(name = "description", required = false) String description) {
+
+        if (name != null) {
+            return service.getByName(name);
+        }
+
+        if (description != null) {
+            return service.getByDescription(description);
+        }
+
+        // Return all cats if no search criteria is specified
+        return service.all();
     }
 
     @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -33,6 +67,33 @@ public class CatsController {
     public @ResponseBody
     Cat
     create(@RequestBody Cat cat) {
-        return service.create(cat);
+    	try {
+            return service.create(cat);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+        
     }
+    
+    @DeleteMapping(value = "/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable String id) {
+    	try {
+            service.delete(id);
+        } catch (AnimalNotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    Cat update(@PathVariable String id, @RequestBody Cat cat) {
+    	 try {
+             return service.update(id, cat);
+         } catch (AnimalNotFoundException e) {
+             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+         }
+    }
+
+    
 }

--- a/src/main/java/cx/catapult/animals/web/CatsController.java
+++ b/src/main/java/cx/catapult/animals/web/CatsController.java
@@ -26,74 +26,67 @@ import cx.catapult.animals.service.CatsService;
 @RequestMapping(path = "/api/1/cats", produces = MediaType.APPLICATION_JSON_VALUE)
 public class CatsController {
 
-    @Autowired
-    private CatsService service;
+	@Autowired
+	private CatsService service;
 
-    @GetMapping(value = "", produces = "application/json")
-    public @ResponseBody
-    Collection<Cat> all() {
-        return service.all();
-    }
+	@GetMapping(value = "", produces = "application/json")
+	public @ResponseBody Collection<Cat> all() {
+		return service.all();
+	}
 
-    @GetMapping(value = "/{id}")
-    public @ResponseBody
-    Cat get(@PathVariable String id) {
-    	try {
-            return service.get(id);
-        } catch (AnimalNotFoundException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-    }
-    
-    @GetMapping(value = "/search", produces = "application/json")
-    public @ResponseBody Collection<Cat> search(
-            @RequestParam(name = "name", required = false) String name,
-            @RequestParam(name = "description", required = false) String description) {
+	@GetMapping(value = "/{id}")
+	public @ResponseBody Cat get(@PathVariable String id) {
+		try {
+			return service.get(id);
+		} catch (AnimalNotFoundException e) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+		}
+	}
 
-        if (name != null) {
-            return service.getByName(name);
-        }
+	@GetMapping(value = "/search", produces = "application/json")
+	public @ResponseBody Collection<Cat> search(@RequestParam(name = "name", required = false) String name,
+			@RequestParam(name = "description", required = false) String description) {
 
-        if (description != null) {
-            return service.getByDescription(description);
-        }
+		if (name != null) {
+			return service.getByName(name);
+		}
 
-        // Return all cats if no search criteria is specified
-        return service.all();
-    }
+		if (description != null) {
+			return service.getByDescription(description);
+		}
 
-    @PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.CREATED)
-    public @ResponseBody
-    Cat
-    create(@RequestBody Cat cat) {
-    	try {
-            return service.create(cat);
-        } catch (IllegalArgumentException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
-        }
-        
-    }
-    
-    @DeleteMapping(value = "/{id}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable String id) {
-    	try {
-            service.delete(id);
-        } catch (AnimalNotFoundException e) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-        }
-    }
+		// Return all cats if no search criteria is specified
+		return service.all();
+	}
 
-    @PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody
-    Cat update(@PathVariable String id, @RequestBody Cat cat) {
-    	 try {
-             return service.update(id, cat);
-         } catch (AnimalNotFoundException e) {
-             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
-         }
-    }
+	@PostMapping(value = "", consumes = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseStatus(HttpStatus.CREATED)
+	public @ResponseBody Cat create(@RequestBody Cat cat) {
+		try {
+			return service.create(cat);
+		} catch (IllegalArgumentException e) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+		}
 
-    
+	}
+
+	@DeleteMapping(value = "/{id}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void delete(@PathVariable String id) {
+		try {
+			service.delete(id);
+		} catch (AnimalNotFoundException e) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+		}
+	}
+
+	@PutMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+	public @ResponseBody Cat update(@PathVariable String id, @RequestBody Cat cat) {
+		try {
+			return service.update(id, cat);
+		} catch (AnimalNotFoundException e) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+		}
+	}
+
 }

--- a/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
@@ -1,50 +1,75 @@
 package cx.catapult.animals.service;
 
-import cx.catapult.animals.domain.Cat;
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.exception.AnimalNotFoundException;
 
 public class CatsServiceTest {
 
-    CatsService service = new CatsService();
-    Cat cat = new Cat("Tom", "Bob cat");
+	CatsService service = new CatsService();
+	Cat cat = new Cat("Tom", "Bob cat");
 
-    @Test
-    public void createShouldWork() throws Exception {
-        Cat thisCat = new Cat();
-        thisCat.setName("Jerry");
-        thisCat.setDescription("Mouse Cat");
-        Cat actual = service.create(thisCat);
-        assertThat(actual).isEqualTo(thisCat);
-        assertThat(actual.getName()).isEqualTo(thisCat.getName());
-        assertThat(actual.getDescription()).isEqualTo(thisCat.getDescription());
-        assertThat(actual.getGroup()).isEqualTo(thisCat.getGroup());
-    }
+	@Test
+	public void createShouldWork() throws Exception {
+		Cat thisCat = new Cat();
+		thisCat.setName("Jerry");
+		thisCat.setDescription("Mouse Cat");
+		Cat actual = service.create(thisCat);
+		assertThat(actual).isEqualTo(thisCat);
+		assertThat(actual.getName()).isEqualTo(thisCat.getName());
+		assertThat(actual.getDescription()).isEqualTo(thisCat.getDescription());
+		assertThat(actual.getGroup()).isEqualTo(thisCat.getGroup());
+	}
 
-    @Test
-    public void allShouldWork() throws Exception {
-        service.create(cat);
-        assertThat(service.all().size()).isEqualTo(1);
-    }
+	@Test
+	public void createShouldFailIfNameOrDescriptionIsMissing() throws Exception {
+		Cat thisCat = new Cat();
+		assertThatThrownBy(() -> service.create(thisCat)).isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Name and description are required fields");
+	}
 
-    @Test
-    public void getShouldWork() throws Exception {
-        service.create(cat);
-        Cat actual = service.get(cat.getId());
-        assertThat(actual).isEqualTo(cat);
-        assertThat(actual.getName()).isEqualTo(cat.getName());
-        assertThat(actual.getDescription()).isEqualTo(cat.getDescription());
-        assertThat(actual.getGroup()).isEqualTo(cat.getGroup());
-    }
-    
-    @Test
-    public void deleteShouldWork() throws Exception {
-        service.create(cat);
+	@Test
+	public void allShouldWork() throws Exception {
+		service.create(cat);
+		assertThat(service.all().size()).isEqualTo(1);
+	}
 
-        service.delete(cat.getId());
+	@Test
+	public void getShouldWork() throws Exception {
+		service.create(cat);
+		Cat actual = service.get(cat.getId());
+		assertThat(actual).isEqualTo(cat);
+		assertThat(actual.getName()).isEqualTo(cat.getName());
+		assertThat(actual.getDescription()).isEqualTo(cat.getDescription());
+		assertThat(actual.getGroup()).isEqualTo(cat.getGroup());
+	}
 
-        assertThat(service.get(cat.getId())).isNull();
-        assertThat(service.all().size()).isEqualTo(0);
-    }
+	@Test
+	public void getShouldFailIfIdIsInvalid() {
+		String id = "id";
+		assertThatThrownBy(() -> service.get(id)).isInstanceOf(AnimalNotFoundException.class)
+				.hasMessageContaining(String.format("Animal not found with id: %s", id));
+	}
+
+	@Test
+	public void deleteShouldWork() throws Exception {
+		service.create(cat);
+
+		service.delete(cat.getId());
+
+		assertThat(service.get(cat.getId())).isNull();
+		assertThat(service.all().size()).isEqualTo(0);
+	}
+
+	@Test
+	public void deleteShouldFail() throws Exception {
+		String id = "id";
+		assertThatThrownBy(() -> service.delete(id)).isInstanceOf(AnimalNotFoundException.class)
+				.hasMessageContaining(String.format("Animal not found with id:  %s", id));
+	}
 }

--- a/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
@@ -37,4 +37,14 @@ public class CatsServiceTest {
         assertThat(actual.getDescription()).isEqualTo(cat.getDescription());
         assertThat(actual.getGroup()).isEqualTo(cat.getGroup());
     }
+    
+    @Test
+    public void deleteShouldWork() throws Exception {
+        service.create(cat);
+
+        service.delete(cat.getId());
+
+        assertThat(service.get(cat.getId())).isNull();
+        assertThat(service.all().size()).isEqualTo(0);
+    }
 }

--- a/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
@@ -3,8 +3,11 @@ package cx.catapult.animals.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
-import org.springframework.web.server.ResponseStatusException;
 
 import cx.catapult.animals.domain.Cat;
 import cx.catapult.animals.exception.AnimalNotFoundException;
@@ -13,6 +16,8 @@ public class CatsServiceTest {
 
 	CatsService service = new CatsService();
 	Cat cat = new Cat("Tom", "Bob cat");
+	Cat cat2 = new Cat("Mat", "Mat cat");
+	Cat cat3 = new Cat("Pat", "Pat cat");
 
 	@Test
 	public void createShouldWork() throws Exception {
@@ -70,5 +75,55 @@ public class CatsServiceTest {
 		String id = "id";
 		assertThatThrownBy(() -> service.delete(id)).isInstanceOf(AnimalNotFoundException.class)
 				.hasMessageContaining(String.format("Animal not found with id: %s", id));
+	}
+	
+	@Test
+	public void updateShouldWork() throws Exception{
+		service.create(cat);
+		String id = cat.getId();
+		
+		Cat newDetails = new Cat("John","Johnny Cat");
+		service.update(id, newDetails);
+		
+		Cat updatedCat = service.get(id);
+		assertThat(updatedCat.getName()).isEqualTo("John");
+		assertThat(updatedCat.getDescription()).isEqualTo("Johnny Cat");
+	}
+	
+	@Test
+	public void updateShouldFail() throws Exception{
+		String id = "id";
+		service.create(cat);
+		
+		Cat newDetails = new Cat("John","Johnny Cat");
+		
+		assertThatThrownBy(() -> service.update(id,newDetails)).isInstanceOf(AnimalNotFoundException.class)
+		.hasMessageContaining(String.format("Animal not found with id: %s", id));
+	}
+	
+	@Test
+	public void getByNameShouldWork() throws Exception{
+		service.create(cat);
+		service.create(cat2);
+		service.create(cat3);
+		
+		Collection<Cat> filteredCats = service.getByName("Tom");
+		
+		assertThat(filteredCats)
+        .extracting(Cat::getName)
+        .contains("Tom");
+	}
+	
+	@Test
+	public void getByDescriptionShouldWork() throws Exception{
+		service.create(cat);
+		service.create(cat2);
+		service.create(cat3);
+		
+		Collection<Cat> filteredCats = service.getByDescription("Pat cat");
+		
+		assertThat(filteredCats)
+        .extracting(Cat::getDescription)
+        .contains("Pat cat");
 	}
 }

--- a/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
+++ b/src/test/java/cx/catapult/animals/service/CatsServiceTest.java
@@ -62,7 +62,6 @@ public class CatsServiceTest {
 
 		service.delete(cat.getId());
 
-		assertThat(service.get(cat.getId())).isNull();
 		assertThat(service.all().size()).isEqualTo(0);
 	}
 
@@ -70,6 +69,6 @@ public class CatsServiceTest {
 	public void deleteShouldFail() throws Exception {
 		String id = "id";
 		assertThatThrownBy(() -> service.delete(id)).isInstanceOf(AnimalNotFoundException.class)
-				.hasMessageContaining(String.format("Animal not found with id:  %s", id));
+				.hasMessageContaining(String.format("Animal not found with id: %s", id));
 	}
 }

--- a/src/test/java/cx/catapult/animals/web/CatsControllerIT.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerIT.java
@@ -1,67 +1,129 @@
 package cx.catapult.animals.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 
-import cx.catapult.animals.domain.Cat;
+import java.net.URL;
+import java.util.Collection;
+
+import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
-import java.net.URL;
-import java.util.Collection;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
+import cx.catapult.animals.domain.Cat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 
 public class CatsControllerIT {
-    @LocalServerPort
-    private int port;
+	@LocalServerPort
+	private int port;
 
-    private URL base;
+	private URL base;
 
-    private Cat cat = new Cat("Tom", "Bob cat");
+	private Cat cat = new Cat("Tom", "Bob cat");
 
-    @Autowired
-    private TestRestTemplate template;
+	@Autowired
+	private TestRestTemplate template;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        this.base = new URL("http://localhost:" + port + "/api/1/cats");
-    }
+	@BeforeEach
+	public void setUp() throws Exception {
+		this.base = new URL("http://localhost:" + port + "/api/1/cats");
+	}
 
-    @Test
-    public void createShouldWork() throws Exception {
-        ResponseEntity<Cat> response = template.postForEntity(base.toString(), cat, Cat.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        assertThat(response.getBody().getId()).isNotEmpty();
-        assertThat(response.getBody().getName()).isEqualTo(cat.getName());
-        assertThat(response.getBody().getDescription()).isEqualTo(cat.getDescription());
-        assertThat(response.getBody().getGroup()).isEqualTo(cat.getGroup());
-    }
+	@Test
+	public void createShouldWork() throws Exception {
+		ResponseEntity<Cat> response = template.postForEntity(base.toString(), cat, Cat.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+		assertThat(response.getBody().getId()).isNotEmpty();
+		assertThat(response.getBody().getName()).isEqualTo(cat.getName());
+		assertThat(response.getBody().getDescription()).isEqualTo(cat.getDescription());
+		assertThat(response.getBody().getGroup()).isEqualTo(cat.getGroup());
+	}
 
-    @Test
-    public void allShouldWork() throws Exception {
-        Collection items = template.getForObject(base.toString(), Collection.class);
-        assertThat(items.size()).isGreaterThanOrEqualTo(7);
-    }
+	@Test
+	public void createShouldFail() throws Exception {
+	    // Create a JSON object with a missing "name" field
+	    JSONObject json = new JSONObject();
+	    json.put("description", "Cat without name");
+	    
+	    HttpHeaders headers = new HttpHeaders();
+	    headers.setContentType(MediaType.APPLICATION_JSON);
+	    HttpEntity<String> request = new HttpEntity<>(json.toString(), headers);
 
-    @Test
-    public void getShouldWork() throws Exception {
-        Cat created = create("Test 1");
-        ResponseEntity<String> response = template.getForEntity(base.toString() + "/" + created.getId(), String.class);
-        assertThat(response.getBody()).isNotEmpty();
-    }
+	    ResponseEntity<String> response = template.postForEntity(base.toString(), request, String.class);
+	    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+	}
 
-    Cat create(String name) {
-        Cat created = template.postForObject(base.toString(), new Cat(name, name), Cat.class);
-        assertThat(created.getId()).isNotEmpty();
-        assertThat(created.getName()).isEqualTo(name);
-        return created;
-    }
+	@Test
+	public void allShouldWork() throws Exception {
+		Collection items = template.getForObject(base.toString(), Collection.class);
+		assertThat(items.size()).isGreaterThanOrEqualTo(7);
+	}
+
+	@Test
+	public void getShouldWork() throws Exception {
+		Cat created = create("Test 1");
+		ResponseEntity<String> response = template.getForEntity(base.toString() + "/" + created.getId(), String.class);
+		assertThat(response.getBody()).isNotEmpty();
+	}
+
+	@Test
+	public void getShouldFail() throws Exception {
+		ResponseEntity<String> response = template.getForEntity(base.toString() + "/" + "invalid id", String.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	public void deleteShouldWork() throws Exception {
+		Cat created = create("Test 2");
+		ResponseEntity<Void> response = template.exchange(base.toString() + "/" + created.getId(),
+				org.springframework.http.HttpMethod.DELETE, null, Void.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+	}
+
+	@Test
+	public void deleteShouldFail() throws Exception {
+		ResponseEntity<Void> response = template.exchange(base.toString() + "/" + "invalid id",
+				org.springframework.http.HttpMethod.DELETE, null, Void.class);
+
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	public void updateShouldWork() throws Exception {
+		Cat catToUpdate = create("Test 3");
+		catToUpdate.setName("Updated cat");
+		catToUpdate.setDescription("Updated description");
+		ResponseEntity<Cat> response = template.exchange(base.toString() + "/" + catToUpdate.getId(), HttpMethod.PUT,
+				new HttpEntity<>(catToUpdate), Cat.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody().getName()).isEqualTo(catToUpdate.getName());
+		assertThat(response.getBody().getDescription()).isEqualTo(catToUpdate.getDescription());
+	}
+
+	@Test
+	public void updateShouldFail() throws Exception {
+		Cat catToUpdate = create("Test 4");
+		catToUpdate.setId("invalid id");
+		ResponseEntity<Void> response = template.exchange(base.toString() + "/" + catToUpdate.getId(), HttpMethod.PUT,
+				new HttpEntity<>(catToUpdate), Void.class);
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	Cat create(String name) {
+		Cat created = template.postForObject(base.toString(), new Cat(name, name), Cat.class);
+		assertThat(created.getId()).isNotEmpty();
+		assertThat(created.getName()).isEqualTo(name);
+		return created;
+	}
 }

--- a/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
+++ b/src/test/java/cx/catapult/animals/web/CatsControllerTest.java
@@ -1,17 +1,24 @@
 package cx.catapult.animals.web;
 
-import cx.catapult.animals.domain.Cat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import cx.catapult.animals.domain.Cat;
+import cx.catapult.animals.exception.AnimalNotFoundException;
+import cx.catapult.animals.service.CatsService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -19,6 +26,9 @@ public class CatsControllerTest {
 
     @Autowired
     private MockMvc mvc;
+    
+    @MockBean
+    private CatsService service;
 
     private Cat cat = new Cat("Tom", "Bob cat");
     private String json = "{ \"name\": \"Tom\", \"description\": \"Bob cat\" }";
@@ -31,13 +41,82 @@ public class CatsControllerTest {
 
     @Test
     public void get() throws Exception {
+    	cat.setId("123");
+    	
+    	when(service.get("123")).thenReturn(cat);
+    	
         mvc.perform(MockMvcRequestBuilders.get("/api/1/cats/123").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
 
     @Test
+    public void getFail() throws Exception {
+    	cat.setId("123");
+    	
+    	when(service.get("123")).thenThrow(AnimalNotFoundException.class);
+    	
+        mvc.perform(MockMvcRequestBuilders.get("/api/1/cats/123").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+    
+    @Test
     public void create() throws Exception {
         mvc.perform(MockMvcRequestBuilders.post("/api/1/cats").content(json).contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isCreated());
     }
+    
+    @Test
+    public void createFail() throws Exception {
+    	doThrow(IllegalArgumentException.class).when(service).create(any(Cat.class));
+    	
+    	
+    	mvc.perform(MockMvcRequestBuilders.post("/api/1/cats").content(json).contentType(MediaType.APPLICATION_JSON_VALUE))
+    	.andExpect(status().isBadRequest());
+    }
+    
+    @Test
+    public void getByName() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.get("/api/1/cats/search?name=Tom").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getByDescription() throws Exception {
+        mvc.perform(MockMvcRequestBuilders.get("/api/1/cats/search?description=Bob cat").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void update() throws Exception {
+    	Cat updatedCat = new Cat("Tommy", "Bob cat updated");
+    	updatedCat.setId("123");
+    	
+    	when(service.update("123", updatedCat)).thenReturn(updatedCat);
+    	
+        String json = "{ \"name\": \"Tommy\", \"description\": \"Bob cat updated\" }";
+        mvc.perform(MockMvcRequestBuilders.put("/api/1/cats/123").content(json).contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+    }
+    
+    @Test
+    public void updateFail() throws Exception {    	
+    	when(service.update(eq("123"), any(Cat.class))).thenThrow(AnimalNotFoundException.class);
+
+    	
+    	String json = "{ \"name\": \"Tommy\", \"description\": \"Bob cat updated\" }";
+    	mvc.perform(MockMvcRequestBuilders.put("/api/1/cats/123").content(json).contentType(MediaType.APPLICATION_JSON_VALUE))
+    	.andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void delete() throws Exception {
+    	cat.setId("123");
+    	
+    	doNothing().when(service).delete("123");
+    	
+        mvc.perform(MockMvcRequestBuilders.delete("/api/1/cats/123").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+    
+    
 }


### PR DESCRIPTION
 I have extended the existing API codebase to deliver the requirements and updated the tests for the new methods while ensuring high test coverage.

I have added the following functionalities:

1. Store cat information
2. Delete cat
3. Update cat information
4. Filter cats
For the filter functionality, I have used query strings for filter parameters and performed the filtering in the API layer.

Please review my work and let me know if any further improvements can be made. Thank you for considering my application.